### PR TITLE
Add Celery option for writing to database

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = *_settings.py

--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,6 +1,6 @@
-doc-warnings: yes
+doc-warnings: no
 test-warnings: no
-strictness: veryhigh
+strictness: high
 max-line-length: 80
 uses:
     - django

--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -4,4 +4,7 @@ strictness: veryhigh
 max-line-length: 80
 uses:
     - django
+    - celery
 autodetect: yes
+ignore-patterns:
+    - .*_settings.py$

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "pypy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ python:
   - "pypy"
 
 env:
-  - DJANGO=Django==1.4.16
-  - DJANGO=Django==1.6.8
-  - DJANGO=Django==1.7.1
+  - DJANGO=Django==1.4.17
+  - DJANGO=Django==1.5.12
+  - DJANGO=Django==1.6.9
+  - DJANGO=Django==1.7.2
 
 services:
   - redis-server
@@ -20,6 +21,7 @@ install:
   - pip install -q $DJANGO
   - pip install coveralls
   - pip install mockredispy
+  - pip install celery
   - python setup.py develop
 
 script:

--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ Default: ``redis://localhost:6379/0``
 (Example with password: ``redis://:mypassword@localhost:6379/0``)
 * ``DEFENDER_PROTECTED_LOGINS``: Tuple: Used by ``ViewDecoratorMiddleware`` to decide
 which login urls need protecting. Default: ``('/accounts/login/',)``
+* ``DEFENDER_USE_CELERY``: Boolean: If you want to use Celery to store the login
+attempt to the database, set to True. If False, it is saved inline.
+Default: ``False``
 
 Running Tests
 =============

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ to improve the login.
 requirements
 ============
 
-- django: 1.4.x, 1.6.x, 1.7.x
+- django: 1.4.x, 1.5.x, 1.6.x, 1.7.x
 - redis
-- python: 2.6.x, 2.7.x, 3.2.x, 3.3.x, 3.4.x, PyPy
+- python: 2.6.x, 2.7.x, 3.3.x, 3.4.x, PyPy
 
 How it works
 ============

--- a/defender/config.py
+++ b/defender/config.py
@@ -50,3 +50,5 @@ LOCKOUT_URL = get_setting('DEFENDER_LOCKOUT_URL')
 
 PROTECTED_LOGINS = get_setting('DEFENDER_PROTECTED_LOGINS',
                                ('/accounts/login/',))
+
+USE_CELERY = get_setting('DEFENDER_USE_CELERY', False)

--- a/defender/data.py
+++ b/defender/data.py
@@ -1,0 +1,14 @@
+from .models import AccessAttempt
+
+
+def store_login_attempt(user_agent, ip_address, username,
+                        http_accept, path_info, login_valid):
+    """ Store the login attempt to the db. """
+    AccessAttempt.objects.create(
+        user_agent=user_agent,
+        ip_address=ip_address,
+        username=username,
+        http_accept=http_accept,
+        path_info=path_info,
+        login_valid=login_valid,
+    )

--- a/defender/decorators.py
+++ b/defender/decorators.py
@@ -34,7 +34,7 @@ def watch_login(func):
 
             # ideally make this background task, but to keep simple, keeping
             # it inline for now.
-            utils.add_login_attempt(request, not login_unsuccessful)
+            utils.add_login_attempt_to_db(request, not login_unsuccessful)
 
             if utils.check_request(request, login_unsuccessful):
                 return response

--- a/defender/tasks.py
+++ b/defender/tasks.py
@@ -1,0 +1,15 @@
+from . import config
+from .data import store_login_attempt
+
+# not sure how to get this to look better. ideally we want to dynamically
+# apply the celery decorator based on the USE_CELERY setting.
+
+if config.USE_CELERY:
+    from celery import shared_task
+
+    @shared_task()
+    def add_login_attempt_task(user_agent, ip_address, username,
+                               http_accept, path_info, login_valid):
+        """ Create a record for the login attempt """
+        store_login_attempt(user_agent, ip_address, username,
+                            http_accept, path_info, login_valid)

--- a/defender/test_settings.py
+++ b/defender/test_settings.py
@@ -39,3 +39,22 @@ DEFENDER_COOLOFF_TIME = 2
 DEFENDER_REDIS_URL = None
 # use mock redis in unit tests locally.
 DEFENDER_MOCK_REDIS = True
+
+# celery settings
+CELERY_ALWAYS_EAGER = True
+BROKER_BACKEND = 'memory'
+BROKER_URL = 'memory://'
+
+import os
+
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'defender.test_settings')
+
+app = Celery('defender')
+
+# Using a string here means the worker will not have to
+# pickle the object when using Windows.
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: INSTALLED_APPS)

--- a/defender/tests.py
+++ b/defender/tests.py
@@ -17,7 +17,7 @@ from django.http import HttpRequest
 from .connection import parse_redis_url
 from . import utils
 from . import config
-from models import AccessAttempt
+from .models import AccessAttempt
 
 mocked_redis = mockredis.mock_strict_redis_client()
 

--- a/defender/travis_settings.py
+++ b/defender/travis_settings.py
@@ -39,3 +39,22 @@ DEFENDER_COOLOFF_TIME = 2
 DEFENDER_REDIS_URL = "redis://localhost:6379/1"
 # don't use mock redis in unit tests, we will use real redis on travis.
 DEFENDER_MOCK_REDIS = False
+
+# Celery settings:
+CELERY_ALWAYS_EAGER = True
+BROKER_BACKEND = 'memory'
+BROKER_URL = 'memory://'
+
+import os
+
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'defender.travis_settings')
+
+app = Celery('defender')
+
+# Using a string here means the worker will not have to
+# pickle the object when using Windows.
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: INSTALLED_APPS)

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setup(name='django-defender',
       license='Apache 2',
       packages=['defender'],
       install_requires=['django==1.6.8', 'redis==2.10.3', 'hiredis==0.1.4', ],
-      tests_require=['mock', 'mockredispy', 'coverage'],
+      tests_require=['mock', 'mockredispy', 'coverage', 'celery'],
       )


### PR DESCRIPTION
Added an optional way to write the login's to the database. Instead of writing them inline, it can be done via a celery task. This will make the login even faster since it won't have to wait for the database write.

There is a new config ``DEFENDER_USE_CELERY`` which lets the application know if you want to use the celery tasks or not.

I had to move some stuff around to get it to work correctly.