### PR TITLE
Provide helper TestCases to be used with Defender

### DIFF
--- a/defender/test.py
+++ b/defender/test.py
@@ -1,0 +1,22 @@
+from django.test.testcases import TestCase, TransactionTestCase
+
+from .connection import get_redis_connection
+
+
+class DefenderTestCaseMixin(object):
+    """Mixin used to provide a common tearDown method"""
+
+    def tearDown(self):
+        """cleanup django-defender cache after each test"""
+        super(DefenderTestCaseMixin, self).tearDown()
+        get_redis_connection().flushdb()
+
+
+class DefenderTransactionTestCase(DefenderTestCaseMixin, TransactionTestCase):
+    """Helper TransactionTestCase that cleans the cache after each test"""
+    pass
+
+
+class DefenderTestCase(DefenderTestCaseMixin, TestCase):
+    """Helper TestCase that cleans the cache after each test"""
+    pass


### PR DESCRIPTION
Provide TransactionTestCase and TestCase that clear the defender cache between runs.

That should allow users of defender to easier integrate defender with their projects.

Note: There's a bit of duplication between DefenderTestCaseTest and DefenderTransactionTestCaseTest. That's on purpose as I am not a big fan of two many dependencies between test cases.

@kencochrane What do you think?

