### PR TITLE
User and ip lockout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ backend best fits their needs.
 Build status
 ------------
 
-[![Build Status](https://travis-ci.org/kencochrane/django-defender.svg)](https://travis-ci.org/kencochrane/django-defender) [![Coverage Status](https://img.shields.io/coveralls/kencochrane/django-defender.svg)](https://coveralls.io/r/kencochrane/django-defender)[![Code Health](https://landscape.io/github/kencochrane/django-defender/master/landscape.svg)](https://landscape.io/github/kencochrane/django-defender/master)
+[![Build Status](https://travis-ci.org/mrbaboon/django-defender.svg)](https://travis-ci.org/mrbaboon/django-defender) [![Coverage Status](https://img.shields.io/coveralls/kencochrane/django-defender.svg)](https://coveralls.io/r/kencochrane/django-defender)[![Code Health](https://landscape.io/github/kencochrane/django-defender/master/landscape.svg)](https://landscape.io/github/kencochrane/django-defender/master)
 
 Sites using Defender:
 =====================
@@ -302,7 +302,8 @@ These should be defined in your ``settings.py`` file.
 * ``DEFENDER_LOGIN_FAILURE_LIMIT``: Int: The number of login attempts allowed before a
 record is created for the failed logins.  [Default: ``3``]
 * ``DEFENDER_BEHIND_REVERSE_PROXY``: Boolean: Is defender behind a reverse proxy?
-[Default: False]
+[Default: ``False``]
+* ``DEFENDER_LOCK_OUT_BY_IP_AND_USERNAME``: Boolean: Locks a user out based on a combination of IP and Username.  This stops a user denying access to the application for all other users accessing the app from behind the same IP address. [Default: ``False``]
 * ``DEFENDER_COOLOFF_TIME``: Int: If set, defines a period of inactivity after which
 old failed login attempts will be forgotten. An integer, will be interpreted as a
 number of seconds. If ``0``, the locks will not expire. [Default: ``300``]
@@ -330,7 +331,7 @@ attempt to the database, set to True. If False, it is saved inline.
 * ``DEFENDER_ACCESS_ATTEMPT_EXPIRATION``: Int: Length of time in hours for how
 long to keep the access attempt records in the database before the management
 command cleans them up.
-[Default: 24]
+[Default: ``24``]
 
 
 Running Tests

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ backend best fits their needs.
 Build status
 ------------
 
-[![Build Status](https://travis-ci.org/mrbaboon/django-defender.svg)](https://travis-ci.org/mrbaboon/django-defender) [![Coverage Status](https://img.shields.io/coveralls/kencochrane/django-defender.svg)](https://coveralls.io/r/kencochrane/django-defender)[![Code Health](https://landscape.io/github/kencochrane/django-defender/master/landscape.svg)](https://landscape.io/github/kencochrane/django-defender/master)
+[![Build Status](https://travis-ci.org/kencochrane/django-defender.svg)](https://travis-ci.org/kencochrane/django-defender)  [![Coverage Status](https://img.shields.io/coveralls/kencochrane/django-defender.svg)](https://coveralls.io/r/kencochrane/django-defender)[![Code Health](https://landscape.io/github/kencochrane/django-defender/master/landscape.svg)](https://landscape.io/github/kencochrane/django-defender/master)
 
 Sites using Defender:
 =====================

--- a/defender/config.py
+++ b/defender/config.py
@@ -15,7 +15,8 @@ MOCK_REDIS = get_setting('DEFENDER_MOCK_REDIS', False)
 # see if the user has overridden the failure limit
 FAILURE_LIMIT = get_setting('DEFENDER_LOGIN_FAILURE_LIMIT', 3)
 
-LOCKOUT_BY_IP_USERNAME = get_setting('DEFENDER_LOCK_OUT_BY_IP_AND_USERNAME', False)
+LOCKOUT_BY_IP_USERNAME = get_setting(
+    'DEFENDER_LOCK_OUT_BY_IP_AND_USERNAME', False)
 
 # use a specific username field to retrieve from login POST data
 USERNAME_FORM_FIELD = get_setting('DEFENDER_USERNAME_FORM_FIELD', 'username')

--- a/defender/config.py
+++ b/defender/config.py
@@ -15,6 +15,8 @@ MOCK_REDIS = get_setting('DEFENDER_MOCK_REDIS', False)
 # see if the user has overridden the failure limit
 FAILURE_LIMIT = get_setting('DEFENDER_LOGIN_FAILURE_LIMIT', 3)
 
+LOCKOUT_BY_IP_USERNAME = get_setting('DEFENDER_LOCK_OUT_BY_IP_AND_USERNAME', False)
+
 # use a specific username field to retrieve from login POST data
 USERNAME_FORM_FIELD = get_setting('DEFENDER_USERNAME_FORM_FIELD', 'username')
 

--- a/defender/utils.py
+++ b/defender/utils.py
@@ -253,7 +253,8 @@ def is_already_locked(request):
     if config.LOCKOUT_BY_IP_USERNAME:
         LOG.info("Block by ip & username")
         if ip_blocked and user_blocked:
-            # if both this IP and this username are present the reqeust is blocked
+            # if both this IP and this username are present the request is
+            # blocked
             return True
 
     else:


### PR DESCRIPTION
Allow username and IP to be mutually exclusive when performing lockouts.  This resolves an issue where you may have many users behind a single IP (common amongst our enterprise customers) where 1 user forgetting their password will lock out their peers.

The setting changes the lockout checks to evaluate if the IP failure limit *and* the username failure limit has been reached before issuing the lockout.

Any suggestions or comments are more than welcome!