### PR TITLE
Added  DEFENDER_DISABLE_IP_LOCKOUT so that you can disable IP lockouts if you want

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
 
 env:
   - DJANGO=Django==1.6.11
-  - DJANGO=Django==1.7.8
-  - DJANGO=Django==1.8.2
+  - DJANGO=Django==1.7.10
+  - DJANGO=Django==1.8.5
+  - DJANGO=Django==1.9b1
 
 services:
   - redis-server
@@ -29,9 +31,11 @@ script:
 matrix:
   exclude:
     - python: "2.6"
-      env: DJANGO=Django==1.7.8
+      env: DJANGO=Django==1.7.10
     - python: "2.6"
-      env: DJANGO=Django==1.8.2
+      env: DJANGO=Django==1.8.5
+    - python: "2.6"
+      env: DJANGO=Django==1.9b1
 
 after_success:
   - coveralls --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,10 @@ matrix:
       env: DJANGO=Django==1.8.5
     - python: "2.6"
       env: DJANGO=Django==1.9b1
+    - python: "3.5"
+      env: DJANGO=Django==1.6.11
+    - python: "3.5"
+      env: DJANGO=Django==1.7.10
 
 after_success:
   - coveralls --verbose

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.4.0
+=====
+added ``DEFENDER_DISABLE_IP_LOCKOUT`` and added support for Python 3.5
+
 0.3.2
 =====
 added ``DEFENDER_LOCK_OUT_BY_IP_AND_USERNAME``, and changed settings to support

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Sites using Defender:
 
 Versions
 ========
+- 0.4.0 - added ``DEFENDER_DISABLE_IP_LOCKOUT`` and added support for Python 3.5
 - 0.3.2 - added ``DEFENDER_LOCK_OUT_BY_IP_AND_USERNAME``, and changed settings
     to support django 1.8.
 - 0.3.1 - fixed the management command name
@@ -306,6 +307,7 @@ record is created for the failed logins.  [Default: ``3``]
 * ``DEFENDER_BEHIND_REVERSE_PROXY``: Boolean: Is defender behind a reverse proxy?
 [Default: ``False``]
 * ``DEFENDER_LOCK_OUT_BY_IP_AND_USERNAME``: Boolean: Locks a user out based on a combination of IP and Username.  This stops a user denying access to the application for all other users accessing the app from behind the same IP address. [Default: ``False``]
+* ``DEFENDER_DISABLE_IP_LOCKOUT``: Boolean: If this is True, it will not lockout the users IP address, it will only lockout the username. [Default: False]
 * ``DEFENDER_COOLOFF_TIME``: Int: If set, defines a period of inactivity after which
 old failed login attempts will be forgotten. An integer, will be interpreted as a
 number of seconds. If ``0``, the locks will not expire. [Default: ``300``]

--- a/defender/config.py
+++ b/defender/config.py
@@ -15,8 +15,13 @@ MOCK_REDIS = get_setting('DEFENDER_MOCK_REDIS', False)
 # see if the user has overridden the failure limit
 FAILURE_LIMIT = get_setting('DEFENDER_LOGIN_FAILURE_LIMIT', 3)
 
+# If this is True, the lockout checks to evaluate if the IP failure limit and
+# the username failure limit has been reached before issuing the lockout.
 LOCKOUT_BY_IP_USERNAME = get_setting(
     'DEFENDER_LOCK_OUT_BY_IP_AND_USERNAME', False)
+
+# if this is True, The users IP address will not get locked when there are too many login attempts.
+DISABLE_IP_LOCKOUT = get_setting('DEFENDER_DISABLE_IP_LOCKOUT', False)
 
 # use a specific username field to retrieve from login POST data
 USERNAME_FORM_FIELD = get_setting('DEFENDER_USERNAME_FORM_FIELD', 'username')

--- a/defender/config.py
+++ b/defender/config.py
@@ -20,7 +20,8 @@ FAILURE_LIMIT = get_setting('DEFENDER_LOGIN_FAILURE_LIMIT', 3)
 LOCKOUT_BY_IP_USERNAME = get_setting(
     'DEFENDER_LOCK_OUT_BY_IP_AND_USERNAME', False)
 
-# if this is True, The users IP address will not get locked when there are too many login attempts.
+# if this is True, The users IP address will not get locked when
+# there are too many login attempts.
 DISABLE_IP_LOCKOUT = get_setting('DEFENDER_DISABLE_IP_LOCKOUT', False)
 
 # use a specific username field to retrieve from login POST data

--- a/defender/tests.py
+++ b/defender/tests.py
@@ -615,7 +615,7 @@ class AccessAttemptTest(DefenderTestCase):
         # same IP different, usernames
         ip = '74.125.239.60'
         for i in range(0, config.FAILURE_LIMIT+10):
-            login_username = u"{}{}".format(username, i)
+            login_username = u"{0}{1}".format(username, i)
             response = self._login(username=login_username, remote_addr=ip)
             # Check if we are in the same login page
             self.assertContains(response, LOGIN_FORM_KEY)

--- a/defender/utils.py
+++ b/defender/utils.py
@@ -87,6 +87,9 @@ def strip_keys(key_list):
 
 def get_blocked_ips():
     """ get a list of blocked ips from redis """
+    if config.DISABLE_IP_LOCKOUT:
+        # There are no blocked IP's since we disabled them.
+        return []
     key = get_ip_blocked_cache_key("*")
     key_list = [redis_key.decode('utf-8')
                 for redis_key in REDIS_SERVER.keys(key)]
@@ -139,6 +142,9 @@ def block_ip(ip_address):
     if not ip_address:
         # no reason to continue when there is no ip
         return
+    if config.DISABLE_IP_LOCKOUT:
+        # no need to block, we disabled it.
+        return
     key = get_ip_blocked_cache_key(ip_address)
     if config.COOLOFF_TIME:
         REDIS_SERVER.set(key, 'blocked', config.COOLOFF_TIME)
@@ -162,23 +168,40 @@ def record_failed_attempt(ip_address, username):
     """ record the failed login attempt, if over limit return False,
     if not over limit return True """
     # increment the failed count, and get current number
-    ip_count = increment_key(get_ip_attempt_cache_key(ip_address))
+    ip_block = False
+    if not config.DISABLE_IP_LOCKOUT:
+        # we only want to increment the IP if this is disabled.
+        ip_count = increment_key(get_ip_attempt_cache_key(ip_address))
+        # if over the limit, add to block
+        if ip_count > config.FAILURE_LIMIT:
+            block_ip(ip_address)
+            ip_block = True
+
+    user_block = False
     user_count = increment_key(get_username_attempt_cache_key(username))
 
-    ip_block = False
-    user_block = False
-    # if either are over the limit, add to block
-    if ip_count > config.FAILURE_LIMIT:
-        block_ip(ip_address)
-        ip_block = True
+    # if over the limit, add to block
     if user_count > config.FAILURE_LIMIT:
         block_username(username)
         user_block = True
 
+    # if we have this turned on, then there is no reason to look at ip_block
+    # we will just look at user_block, and short circut the result since
+    # we don't need to continue.
+    if config.DISABLE_IP_LOCKOUT:
+        # if user_block is True, it means it was blocked
+        # we need to return False
+        return not user_block
+
+    # we want to make sure both the IP and user is blocked before we return False
+    # this is mostly used when a lot of your users are using proxies, and you
+    # don't want one user to block everyone on that one IP.
     if config.LOCKOUT_BY_IP_USERNAME:
+        # both ip_block and user_block need to be True in order
+        # to return a False.
         return not (ip_block and user_block)
 
-    # if any blocks return False, no blocks return True
+    # if any blocks return False, no blocks. return True
     return not (ip_block or user_block)
 
 
@@ -243,14 +266,23 @@ def lockout_response(request):
 
 def is_already_locked(request):
     """ Is this IP/username already locked? """
-    ip_address = get_ip(request)
-    username = request.POST.get(config.USERNAME_FORM_FIELD, None)
 
-    # ip blocked?
-    ip_blocked = REDIS_SERVER.get(get_ip_blocked_cache_key(ip_address))
+    if not config.DISABLE_IP_LOCKOUT:
+        # ip blocked?
+        ip_address = get_ip(request)
+        ip_blocked = REDIS_SERVER.get(get_ip_blocked_cache_key(ip_address))
+    else:
+        # we disabled ip lockout, so it will never be blocked.
+        ip_blocked = False
 
     # username blocked?
+    username = request.POST.get(config.USERNAME_FORM_FIELD, None)
     user_blocked = REDIS_SERVER.get(get_username_blocked_cache_key(username))
+
+    if config.DISABLE_IP_LOCKOUT:
+        # if DISABLE_IP_LOCKOUT is turned on, then return user_blocked
+        # result, since we don't care about ip at this point.
+        return user_blocked
 
     if config.LOCKOUT_BY_IP_USERNAME:
         LOG.info("Block by ip & username")

--- a/defender/utils.py
+++ b/defender/utils.py
@@ -193,9 +193,10 @@ def record_failed_attempt(ip_address, username):
         # we need to return False
         return not user_block
 
-    # we want to make sure both the IP and user is blocked before we return False
-    # this is mostly used when a lot of your users are using proxies, and you
-    # don't want one user to block everyone on that one IP.
+    # we want to make sure both the IP and user is blocked before we
+    # return False
+    # this is mostly used when a lot of your users are using proxies,
+    # and you don't want one user to block everyone on that one IP.
     if config.LOCKOUT_BY_IP_USERNAME:
         # both ip_block and user_block need to be True in order
         # to return a False.

--- a/defender/utils.py
+++ b/defender/utils.py
@@ -280,28 +280,13 @@ def is_already_locked(request):
     username = request.POST.get(config.USERNAME_FORM_FIELD, None)
     user_blocked = REDIS_SERVER.get(get_username_blocked_cache_key(username))
 
-    if config.DISABLE_IP_LOCKOUT:
-        # if DISABLE_IP_LOCKOUT is turned on, then return user_blocked
-        # result, since we don't care about ip at this point.
-        return user_blocked
-
     if config.LOCKOUT_BY_IP_USERNAME:
         LOG.info("Block by ip & username")
-        if ip_blocked and user_blocked:
-            # if both this IP and this username are present the request is
-            # blocked
-            return True
+        # if both this IP and this username are present the request is
+        # blocked
+        return ip_blocked and user_blocked
 
-    else:
-        if ip_blocked:
-            # short circuit no need to check username if ip is already blocked.
-            return True
-
-        if user_blocked:
-            return True
-
-    # if the username nor ip is blocked, the request is not blocked
-    return False
+    return ip_blocked or user_blocked
 
 
 def check_request(request, login_unsuccessful):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
     from distutils.core import setup
 
 
-version = '0.3.2'
+version = '0.4.0'
 
 
 def get_packages(package):
@@ -54,6 +54,7 @@ setup(name='django-defender',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Programming Language :: Python :: Implementation :: CPython',
           'Topic :: Internet :: WWW/HTTP :: Dynamic Content',


### PR DESCRIPTION
I added the ability to disable the IP locking features, when enabled it will only lock out based on username. 

This would be useful if you have a lot of users that connect via the same proxy, and you want to prevent everyone from getting locked out because of one user's bad login attempts.

I also updated the travisCI settings, to test for newer versions of Django and python 3.5

bumped version to 0.4.0

/cc @bcwalrus @marcusmartins 