### PR TITLE
Add helpers that do not assume how to retrieve `username`

### DIFF
--- a/defender/tasks.py
+++ b/defender/tasks.py
@@ -1,15 +1,14 @@
-from . import config
 from .data import store_login_attempt
 
 # not sure how to get this to look better. ideally we want to dynamically
 # apply the celery decorator based on the USE_CELERY setting.
 
-if config.USE_CELERY:
-    from celery import shared_task
+from celery import shared_task
 
-    @shared_task()
-    def add_login_attempt_task(user_agent, ip_address, username,
-                               http_accept, path_info, login_valid):
-        """ Create a record for the login attempt """
-        store_login_attempt(user_agent, ip_address, username,
-                            http_accept, path_info, login_valid)
+
+@shared_task()
+def add_login_attempt_task(user_agent, ip_address, username,
+                           http_accept, path_info, login_valid):
+    """ Create a record for the login attempt """
+    store_login_attempt(user_agent, ip_address, username,
+                        http_accept, path_info, login_valid)

--- a/defender/tests.py
+++ b/defender/tests.py
@@ -686,3 +686,21 @@ class DefenderTransactionTestCaseTest(DefenderTransactionTestCase):
         utils.REDIS_SERVER.incr(self.key)
         result = int(utils.REDIS_SERVER.get(self.key))
         self.assertEqual(result, 1)
+
+
+class TestUtils(DefenderTestCase):
+    def test_username_blocking(self):
+        username = 'foo'
+        self.assertFalse(utils.is_user_already_locked(username))
+        utils.block_username(username)
+        self.assertTrue(utils.is_user_already_locked(username))
+        utils.unblock_username(username)
+        self.assertFalse(utils.is_user_already_locked(username))
+
+    def test_ip_address_blocking(self):
+        ip = '1.2.3.4'
+        self.assertFalse(utils.is_source_ip_already_locked(ip))
+        utils.block_ip(ip)
+        self.assertTrue(utils.is_source_ip_already_locked(ip))
+        utils.unblock_ip(ip)
+        self.assertFalse(utils.is_source_ip_already_locked(ip))


### PR DESCRIPTION
The `is_already_locked` method assumes how the username is stored in the
request. This patch adds helpers that don't to allow for more flexible
implementation.

/cc: @kencochrane @marcusmartins @fxdgear

*Note*: I'll also push this to `dockerhub/django-defender` master and do a release from there.