### PR TITLE
removing the django admin filter for username

### DIFF
--- a/defender/admin.py
+++ b/defender/admin.py
@@ -12,10 +12,6 @@ class AccessAttemptAdmin(admin.ModelAdmin):
         'login_valid',
     )
 
-    list_filter = [
-        'username',
-    ]
-
     search_fields = [
         'ip_address',
         'username',


### PR DESCRIPTION
removing the django admin filter for username, when you have a lot of records, it will prevent the admin page from displaying, and causes it to be really slow otherwise.