### PR TITLE
making urlpatterns a plain list

### DIFF
--- a/defender/urls.py
+++ b/defender/urls.py
@@ -1,8 +1,7 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from .views import block_view, unblock_ip_view, unblock_username_view
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^blocks/$', block_view,
         name="defender_blocks_view"),
     url(r'^blocks/ip/(?P<ip_address>[a-z0-9-._]+)/unblock$', unblock_ip_view,
@@ -10,4 +9,4 @@ urlpatterns = patterns(
     url(r'^blocks/username/(?P<username>[a-z0-9-._@]+)/unblock$',
         unblock_username_view,
         name="defender_unblock_username_view"),
-)
+]


### PR DESCRIPTION
As of Django 1.8, creating `urlpatterns` with the `django.conf.urls.patterns` function became deprecated and will be [removed in 1.10.](https://docs.djangoproject.com/en/1.8/ref/urls/#patterns).

Note: this may not work with Django 1.6, so if that still needs to be supported some additional testing may be needed.
