### PR TITLE
Allow usernames with plus signs in unblock view

### DIFF
--- a/defender/test_urls.py
+++ b/defender/test_urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url, include
 from django.contrib import admin
 
+from .urls import urlpatterns as original_urlpatterns
+
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-]
+] + original_urlpatterns

--- a/defender/tests.py
+++ b/defender/tests.py
@@ -532,6 +532,16 @@ class AccessAttemptTest(DefenderTestCase):
         from .admin import AccessAttemptAdmin
         AccessAttemptAdmin
 
+    def test_unblock_view_user_with_plus(self):
+        """
+        There is an available admin view for unblocking a user
+        with a plus sign in the username.
+
+        Regression test for #GH76.
+        """
+        reverse('defender_unblock_username_view',
+                kwargs={'username': 'user+test@test.tld'})
+
     def test_decorator_middleware(self):
         # because watch_login is called twice in this test (once by the
         # middleware and once by the decorator) we have half as many attempts

--- a/defender/urls.py
+++ b/defender/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
         name="defender_blocks_view"),
     url(r'^blocks/ip/(?P<ip_address>[A-Za-z0-9-._]+)/unblock$', unblock_ip_view,
         name="defender_unblock_ip_view"),
-    url(r'^blocks/username/(?P<username>[A-Za-z0-9-._@]+)/unblock$',
+    url(r'^blocks/username/(?P<username>[A-Za-z0-9-._@\+]+)/unblock$',
         unblock_username_view,
         name="defender_unblock_username_view"),
 ]


### PR DESCRIPTION
This fixes bug #76 where an exception like

```
Reverse for 'defender_unblock_username_view' with arguments '(u'user+test@domain.tld',)' and keyword arguments '{}' not found. 1 pattern(s) tried: [u'admin/defender/blocks/username/(?P[A-Za-z0-9-._@]+)/unblock$']
```

was raised when trying to access the `/admin/defender/blocks/` URL when a user with a plus sign had been locked out.