### PR TITLE
Middleware fix for django >= 1.10

### DIFF
--- a/defender/middleware.py
+++ b/defender/middleware.py
@@ -1,10 +1,14 @@
+try:
+    from django.utils.deprecation import MiddlewareMixin as MIDDLEWARE_BASE_CLASS
+except ImportError:
+    MIDDLEWARE_BASE_CLASS = object
 from django.contrib.auth import views as auth_views
 from django.utils.decorators import method_decorator
 
 from .decorators import watch_login
 
 
-class FailedLoginMiddleware(object):
+class FailedLoginMiddleware(MIDDLEWARE_BASE_CLASS):
     """ Failed login middleware """
     patched = False
 


### PR DESCRIPTION
#92 Fixes the `TypeError: object.__init__() takes no parameters` that happens with the new MIDDLEWARE that is new in django 1.10