### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.5.1
+=====
+- Middleware fix for django >= 1.10 #93 [@Temeez]
+- Force the username to lowercase #90 [@MattBlack85]
+
 0.5.0
 =====
 - Better support for Django 1.11 [@dukebody]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ If you are using defender on your site, submit a PR to add to the list.
 
 Versions
 ========
+- 0.5.1
+  - Middleware fix for django >= 1.10 #93 [@Temeez]
+  - Force the username to lowercase #90 [@MattBlack85]
+
 - 0.5.0
   - Better support for Django 1.11 [@dukebody]
   - Added support to share redis config with django.core.cache [@Franr]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
     from distutils.core import setup
 
 
-version = '0.5.0'
+version = '0.5.1'
 
 
 def get_packages(package):


### PR DESCRIPTION
Bump version to 0.5.1

0.5.1
=====
- Middleware fix for django >= 1.10 #93 [@Temeez]
- Force the username to lowercase #90 [@MattBlack85]

Signed-off-by: Ken Cochrane <kencochrane@gmail.com>