### PR TITLE
Update regex for 'unblock_username_view'.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.5.2
+====
+* Fix regex in 'unblock_username_view' to handle special symbols [@ruthus18]
+
 0.5.1
 =====
 - Middleware fix for django >= 1.10 #93 [@Temeez]

--- a/defender/tests.py
+++ b/defender/tests.py
@@ -570,6 +570,14 @@ class AccessAttemptTest(DefenderTestCase):
         reverse('defender_unblock_username_view',
                 kwargs={'username': 'user+test@test.tld'})
 
+    def test_unblock_view_user_with_special_symbols(self):
+        """
+        There is an available admin view for unblocking a user
+        with a exclamation mark sign in the username.
+        """
+        reverse('defender_unblock_username_view',
+                kwargs={'username': 'user!test@test.tld'})
+
     def test_decorator_middleware(self):
         # because watch_login is called twice in this test (once by the
         # middleware and once by the decorator) we have half as many attempts

--- a/defender/urls.py
+++ b/defender/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
         name="defender_blocks_view"),
     url(r'^blocks/ip/(?P<ip_address>[A-Za-z0-9-._]+)/unblock$', unblock_ip_view,
         name="defender_unblock_ip_view"),
-    url(r'^blocks/username/(?P<username>[A-Za-z0-9-._@\+]+)/unblock$',
+    url(r'^blocks/username/(?P<username>[\w]+[^\/]*)/unblock$',
         unblock_username_view,
         name="defender_unblock_username_view"),
 ]


### PR DESCRIPTION
 The reason why we need to handle almost all special symbols is in cases when username is like 'some!username'

 Issue: #76