### PR TITLE
removing hiredis dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,6 @@ setup(name='django-defender',
       packages=get_packages('defender'),
       package_data=get_package_data('defender'),
       install_requires=['Django>=1.8,<1.12', 'redis>=2.10.3,<3.0',
-                        'hiredis>=0.2.0,<1.0', 'mockredispy>=2.9.0.11,<3.0'],
+                        'mockredispy>=2.9.0.11,<3.0'],
       tests_require=['mock', 'mockredispy', 'coverage', 'celery', 'django-redis-cache'],
       )


### PR DESCRIPTION
hiredis isn't needed to run this app, therefore it doesn't need to be required by `setup.py`