### PR TITLE
Correctly get raw client when using django_redis cache.

### DIFF
--- a/defender/connection.py
+++ b/defender/connection.py
@@ -34,7 +34,7 @@ def get_redis_connection():
             return cache.get_master_client()
         except AttributeError:
             # django_redis.cache.RedisCache case (django-redis package)
-            return cache._client
+            return cache.client.get_client(True)
     else:  # pragma: no cover
         redis_config = parse_redis_url(config.DEFENDER_REDIS_URL)
         return redis.StrictRedis(


### PR DESCRIPTION
When using the `django_redis.cache.RedisCache` cache the defender is unable to get the raw client successfully. This fixes the issue by using the `client` property and then the `get_client` method to return the raw redis client.