### PR TITLE
Move mockredis to test requirements. 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.5.3
+=====
+- Remove mockredis as install requirement, make only test requirement [@blueyed]
+
 0.5.2
 =====
 - Fix regex in 'unblock_username_view' to handle special symbols [@ruthus18]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ If you are using defender on your site, submit a PR to add to the list.
 
 Versions
 ========
+- 0.5.3 [in progress]
+  - Remove mockredis as install requirement, make only test requirement [@blueyed]
+
 - 0.5.2
   - Fix regex in 'unblock_username_view' to handle special symbols [@ruthus18]
   - Fix django requires version for 1.11.x [@kencochrane]

--- a/defender/connection.py
+++ b/defender/connection.py
@@ -1,6 +1,6 @@
 from django.core.cache import caches
 from django.core.cache.backends.base import InvalidCacheBackendError
-import mockredis
+
 import redis
 try:
     import urlparse
@@ -12,8 +12,6 @@ from . import config
 # Register database schemes in URLs.
 urlparse.uses_netloc.append("redis")
 
-
-MOCKED_REDIS = mockredis.mock_strict_redis_client()
 INVALID_CACHE_ERROR_MSG = 'The cache {} was not found on the django cache' \
                           ' settings.'
 
@@ -21,7 +19,8 @@ INVALID_CACHE_ERROR_MSG = 'The cache {} was not found on the django cache' \
 def get_redis_connection():
     """ Get the redis connection if not using mock """
     if config.MOCK_REDIS:  # pragma: no cover
-        return MOCKED_REDIS  # pragma: no cover
+        import mockredis
+        return mockredis.mock_strict_redis_client()  # pragma: no cover
     elif config.DEFENDER_REDIS_NAME:  # pragma: no cover
         try:
             cache = caches[config.DEFENDER_REDIS_NAME]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
     from distutils.core import setup
 
 
-version = '0.5.2'
+version = '0.5.3'
 
 
 def get_packages(package):
@@ -68,7 +68,7 @@ setup(name='django-defender',
       include_package_data=True,
       packages=get_packages('defender'),
       package_data=get_package_data('defender'),
-      install_requires=['Django>=1.8,<2.1', 'redis>=2.10.3,<3.0',
-                        'mockredispy>=2.9.0.11,<3.0'],
-      tests_require=['mock', 'mockredispy', 'coverage', 'celery', 'django-redis-cache'],
+      install_requires=['Django>=1.8,<2.1', 'redis>=2.10.3,<3.0'],
+      tests_require=['mock', 'mockredispy>=2.9.0.11,<3.0', 'coverage',
+                     'celery', 'django-redis-cache'],
       )


### PR DESCRIPTION
This PR replaces #115 which moves the mockredis requirement to a test requirement from an install requirement.

Signed-off-by: Ken Cochrane <KenCochrane@gmail.com>