### PR TITLE
redispy 3.2.0 compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
     from distutils.core import setup
 
 
-version = '0.6.0'
+version = '0.6.1'
 
 
 def get_packages(package):
@@ -68,7 +68,7 @@ setup(name='django-defender',
       include_package_data=True,
       packages=get_packages('defender'),
       package_data=get_package_data('defender'),
-      install_requires=['Django>=1.8,<2.2', 'redis>=2.10.3,<3.0'],
+      install_requires=['Django>=1.8,<2.2', 'redis>=2.10.3,<=3.2'],
       tests_require=['mock', 'mockredispy>=2.9.0.11,<3.0', 'coverage',
                      'celery', 'django-redis-cache'],
       )


### PR DESCRIPTION
Kombu 4.4 requires redispy 3.2.0 and seems to [fix celery stability issues](https://github.com/celery/kombu/issues/1016), bumping the version should just work according to ["Upgrading from redis-py 2.X to 3.0"](https://pypi.org/project/redis/)