### PR TITLE
Add and test support for Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+dist: xenial
+
 python:
   - "2.7"
   - "3.4"
@@ -10,6 +12,7 @@ env:
   - DJANGO=1.11
   - DJANGO=2.0
   - DJANGO=2.1
+  - DJANGO=2.2
 
 services:
   - redis-server
@@ -32,10 +35,14 @@ matrix:
       env: DJANGO=2.0
     - python: "2.7"
       env: DJANGO=2.1
+    - python: "2.7"
+      env: DJANGO=2.2
     - python: "3.4"
       env: DJANGO=2.0
     - python: "3.4"
       env: DJANGO=2.1
+    - python: "3.4"
+      env: DJANGO=2.2
 
 after_success:
   - coveralls --verbose

--- a/defender/travis_settings.py
+++ b/defender/travis_settings.py
@@ -22,6 +22,7 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
     'defender.middleware.FailedLoginMiddleware',
 )
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(name='django-defender',
       include_package_data=True,
       packages=get_packages('defender'),
       package_data=get_package_data('defender'),
-      install_requires=['Django>=1.8,<2.2', 'redis>=2.10.3,<=3.2'],
+      install_requires=['Django>=1.8,<2.3', 'redis>=2.10.3,<=3.2'],
       tests_require=['mock', 'mockredispy>=2.9.0.11,<3.0', 'coverage',
                      'celery', 'django-redis-cache'],
       )


### PR DESCRIPTION
We've been using latest djang-defender with Django 2.2 since its release and it's been working without any issues that we've seen. We just get annoying pip warnings about it not being officially supported.